### PR TITLE
Add useIsomorphicLayoutEffect to avoid SSR error messages

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 //// @ts-nocheck
 
-import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import isEqual from "lodash.isequal";
 import pick from "lodash.pick";
 import { getElementByPropGiven, typeOf } from "./utils";
@@ -162,7 +162,7 @@ const Xarrow: React.FC<xarrowPropsType> = (props: xarrowPropsType) => {
     initAnchorsRefs();
   }, []);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     // console.log("xarrow rendered!");
     updateIfNeeded();
   });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import { getElementByPropGiven, typeOf } from "./utils";
 import PropTypes from "prop-types";
 import { buzzierMinSols, bzFunction } from "./utils/buzzier";
 import { getShortestLine, prepareAnchorLines } from "./utils/anchors";
+import { useIsomorphicLayoutEffect } from "./utils/useIsomorphicLayoutEffect";
 
 ///////////////
 // public types
@@ -155,7 +156,7 @@ const Xarrow: React.FC<xarrowPropsType> = (props: xarrowPropsType) => {
     setPrevProps(props);
   };
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     // console.log("xarrow mounted");
     initProps();
     initAnchorsRefs();

--- a/src/utils/useIsomorphicLayoutEffect.ts
+++ b/src/utils/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,4 @@
+import { useLayoutEffect, useEffect } from "react";
+
+export const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;


### PR DESCRIPTION
This clears up warning messages when using SSR in frameworks such as Nextjs.