### PR TITLE
Radius offset

### DIFF
--- a/src/Xarrow/Xarrow.tsx
+++ b/src/Xarrow/Xarrow.tsx
@@ -76,8 +76,8 @@ const Xarrow: React.FC<xarrowPropsType> = (props: xarrowPropsType) => {
     cpy2: 0,
     headOrient: 0, // determines to what side the arrowhead will point
     tailOrient: 0, // determines to what side the arrow tail will point
-    arrowHeadOffset: { x: 0, y: 0 },
-    arrowTailOffset: { x: 0, y: 0 },
+    arrowHeadOffset: { x: 0, y: 0, radius: 0 },
+    arrowTailOffset: { x: 0, y: 0, radius: 0 },
     headOffset: 0,
     excRight: 0, //expand canvas to the right
     excLeft: 0, //expand canvas to the left

--- a/src/Xarrow/utils/GetPosition.tsx
+++ b/src/Xarrow/utils/GetPosition.tsx
@@ -1,7 +1,7 @@
 import { useXarrowPropsResType } from '../useXarrowProps';
 import React from 'react';
 import { calcAnchors } from '../anchors';
-import { getShortestLine, getSvgPos } from './index';
+import { calculateRadiusOffset, getShortestLine, getSvgPos } from './index';
 import _ from 'lodash';
 import { cPaths } from '../../constants';
 import { buzzierMinSols, bzFunction } from './buzzier';
@@ -44,8 +44,17 @@ export const getPosition = (xProps: useXarrowPropsResType, mainRef: React.Mutabl
   // choose the smallest path for 2 points from these possibilities.
   let { chosenStart, chosenEnd } = getShortestLine(startPoints, endPoints);
 
+  // Calculate the radius if exists
+  if(chosenStart.anchor.offset.radius && chosenStart.anchor.offset.radius >= 0) {
+    chosenStart.anchor.offset = calculateRadiusOffset(chosenEnd, chosenStart);
+  }
+  if(chosenEnd.anchor.offset.radius && chosenEnd.anchor.offset.radius >= 0) {
+    chosenEnd.anchor.offset = calculateRadiusOffset(chosenStart, chosenEnd);
+  }
+
   let startAnchorPosition = chosenStart.anchor.position,
     endAnchorPosition = chosenEnd.anchor.position;
+
   let startPoint = _.pick(chosenStart, ['x', 'y']),
     endPoint = _.pick(chosenEnd, ['x', 'y']);
 

--- a/src/Xarrow/utils/index.ts
+++ b/src/Xarrow/utils/index.ts
@@ -48,7 +48,7 @@ const dist = (p1, p2) => {
 type t1 = { x: number; y: number; anchor: anchorCustomPositionType };
 
 export const getShortestLine = (sPoints: t1[], ePoints: t1[]) => {
-  // closes tPair Of Points which feet to the specified anchors
+  // closes tPair Of Points which feed to the specified anchors
   let minDist = Infinity,
     d = Infinity;
   let closestPair: { chosenStart: t1; chosenEnd: t1 };
@@ -63,6 +63,19 @@ export const getShortestLine = (sPoints: t1[], ePoints: t1[]) => {
   });
   return closestPair;
 };
+
+export const calculateRadiusOffset = (start: t1, end: t1) => {
+  let radius = end.anchor.offset.radius;
+  let directionMagnitude = dist(start, end);
+  let directionNormalized = { 
+    x: (start.x - end.x) / directionMagnitude, 
+    y: (start.y - end.y) / directionMagnitude 
+  };
+  return { 
+    x: end.x + (directionNormalized.x * radius), 
+    y: end.y + (directionNormalized.y * radius) 
+  };
+}
 
 export const getElemPos = (elem: HTMLElement) => {
   if (!elem) return { x: 0, y: 0, right: 0, bottom: 0 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,7 +55,7 @@ export type anchorNamedType = typeof cAnchorEdge[number];
 
 export type anchorCustomPositionType = {
   position: anchorNamedType;
-  offset: { x?: number; y?: number };
+  offset: { x?: number; y?: number; radius?: number };
 };
 export type refType = React.MutableRefObject<any> | string;
 export type labelsType = {


### PR DESCRIPTION
This PR adds an extra `radius` field to offsets, which enables arrow ends to be shortened by that radius amount.

Related issue: https://github.com/Eliav2/react-xarrows/issues/92  

Note that this hasn't been tested (yet)