### PR TITLE
remove lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "bugs": "https://github.com/Eliav2/react-xarrows/issues",
   "dependencies": {
     "@types/prop-types": "^15.7.3",
-    "lodash": "^4.17.21",
+    "just-compare": "^2.2.2",
+    "just-pick": "^4.1.1",
     "prop-types": "^15.7.2"
   },
   "funding": {
@@ -43,7 +44,6 @@
     "@babel/preset-react": "^7.14.5",
     "@babel/preset-typescript": "^7.14.5",
     "@types/jest": "^26.0.23",
-    "@types/lodash": "^4.14.168",
     "@types/node": "^15.0.1",
     "@types/react": "^16.9.19",
     "@typescript-eslint/eslint-plugin": "^4.27.0",

--- a/src/Xarrow/useXarrowProps.ts
+++ b/src/Xarrow/useXarrowProps.ts
@@ -10,9 +10,9 @@ import {
   xarrowPropsType,
 } from '../types';
 import { getElementByPropGiven, getElemPos, xStr2absRelative } from './utils';
-import _ from 'lodash';
 import { arrowShapes, cAnchorEdge, cArrowShapes } from '../constants';
 import { anchorEdgeType, dimensionType } from '../privateTypes';
+import compare from 'just-compare';
 
 const parseLabels = (label: xarrowPropsType['labels']): labelsType => {
   let parsedLabel = { start: null, middle: null, end: null };
@@ -293,7 +293,7 @@ const initialValVars = {
 // const parseAllProps = () => parseGivenProps(defaultProps, initialParsedProps);
 
 function deepCompareEquals(a, b) {
-  return _.isEqual(a, b);
+  return compare(a, b);
 }
 
 function useDeepCompareMemoize(value) {

--- a/src/Xarrow/utils/GetPosition.tsx
+++ b/src/Xarrow/utils/GetPosition.tsx
@@ -2,9 +2,9 @@ import { useXarrowPropsResType } from '../useXarrowProps';
 import React from 'react';
 import { calcAnchors } from '../anchors';
 import { getShortestLine, getSvgPos } from './index';
-import _ from 'lodash';
 import { cPaths } from '../../constants';
 import { buzzierMinSols, bzFunction } from './buzzier';
+import pick from 'just-pick';
 
 /**
  * The Main logic of path calculation for the arrow.
@@ -46,8 +46,8 @@ export const getPosition = (xProps: useXarrowPropsResType, mainRef: React.Mutabl
 
   let startAnchorPosition = chosenStart.anchor.position,
     endAnchorPosition = chosenEnd.anchor.position;
-  let startPoint = _.pick(chosenStart, ['x', 'y']),
-    endPoint = _.pick(chosenEnd, ['x', 'y']);
+  let startPoint = pick(chosenStart, ['x', 'y']),
+    endPoint = pick(chosenEnd, ['x', 'y']);
 
   let mainDivPos = getSvgPos(svgRef);
   let cx0 = Math.min(startPoint.x, endPoint.x) - mainDivPos.x;

--- a/webpack.libConfig.js
+++ b/webpack.libConfig.js
@@ -12,7 +12,6 @@ module.exports = (env, argv) => {
     externals: [
       {
         react: 'react',
-        lodash: 'lodash',
         'prop-types': 'prop-types',
       },
       // nodeExternals(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1385,11 +1385,6 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/lodash@^4.14.168":
-  version "4.14.168"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
-  integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
-
 "@types/minimatch@*":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
@@ -4848,6 +4843,16 @@ json5@^2.1.2:
   integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
   dependencies:
     minimist "^1.2.5"
+
+just-compare@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/just-compare/-/just-compare-2.2.2.tgz#915d2e52ef36d043a8951c3a9ae11b57534550c1"
+  integrity sha512-CdgzjlMSpfjWv4opv34bKeWmzv89hbKcjoSuJ9Y0ke/DTwFkoGfaLmmdwX5niTfKMldlzX3hJjYgWbX6qE5aRA==
+
+just-pick@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/just-pick/-/just-pick-4.1.1.tgz#2afabce85f40e74b854136323a8e3fa82cd6c995"
+  integrity sha512-pR6Sl3F0SbaBsp/F3jzwB/2soeAvUB3l5KzJYiMh2h0vl7qbkKW9cP6rh6A2SS2QuzKiXYL+nvaHzeNH2pnScg==
 
 killable@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Remove Lodash dependency

Add ''just-extend'' utility functions instead of Lodash. Just functions are smaller + natively written in TypeScript.
_.pick -> pick
_.isEqual -> compare