### PR TITLE
Fix line SVG dotted animation in strict mode

### DIFF
--- a/src/Xarrow/Xarrow.tsx
+++ b/src/Xarrow/Xarrow.tsx
@@ -222,7 +222,7 @@ const Xarrow: React.FC<xarrowPropsType> = (props: xarrowPropsType) => {
               {...(passProps as any)}
               {...arrowBodyProps}>
               <>
-                {drawAnimEnded ? (
+                {drawAnimEnded || !animateDrawing ? (
                   <>
                     {/* moving dashed line animation */}
                     {dashness.animation ? (


### PR DESCRIPTION
This was broken in strict mode. I honestly am not sure how this worked before since `lineDrawAnimRef` (https://github.com/Eliav2/react-xarrows/blob/master/src/Xarrow/Xarrow.tsx#L175) will always be `undefined` (if no drawing animation happens), therefore `handleDrawAmimEnd` is never called.

Fixes https://github.com/Eliav2/react-xarrows/issues/151