### PR TITLE
fix(demo): dedupe React so example routes stop crashing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,22 @@ jobs:
       - name: Build demo
         run: pnpm --filter react-xarrows-examples run build
 
+      # A demo that builds can still be broken on arrival. The library source is
+      # aliased out of the repo root, which installs its own React for tests, so
+      # a second copy can end up in the bundle. Nothing fails at build time; the
+      # site just throws "Cannot read properties of null (reading 'useRef')" on
+      # every route that renders an arrow.
+      - name: Verify the demo bundled exactly one React
+        run: |
+          demo_react=$(node -p "require('./examples/node_modules/react/package.json').version")
+          root_react=$(node -p "require('./node_modules/react/package.json').version")
+          echo "demo React $demo_react, repo root React $root_react"
+          if [ "$demo_react" != "$root_react" ] \
+            && grep -qF "$root_react" examples/dist/assets/*.js; then
+            echo "::error::demo bundle contains React $root_react from the repo root as well as $demo_react"
+            exit 1
+          fi
+
       # Catches the case where `files` or the build output drift apart and the
       # published tarball silently loses the entry point or its type definitions.
       - name: Verify package contents

--- a/examples/vite.config.ts
+++ b/examples/vite.config.ts
@@ -12,6 +12,12 @@ export default defineConfig({
   base,
   plugins: [react()],
   resolve: {
+    // The alias below pulls library source out of the repo root, where pnpm has
+    // installed React 18 for the library's own build and tests. The demo runs
+    // React 19 from examples/. Without deduping, the two halves of the app get
+    // two React copies, the second one's hook dispatcher is null, and every
+    // route that renders an Xarrow throws "Cannot read properties of null".
+    dedupe: ['react', 'react-dom'],
     alias: {
       // Resolve the library straight from source so the demo always reflects
       // this checkout. package.json still declares a real dependency so that


### PR DESCRIPTION
## Problem

Every route on the deployed demo except the home page renders a blank screen.

```
TypeError: Cannot read properties of null (reading 'useRef')
```

Reproduces on https://eliav2.github.io/react-xarrows/#/FewArrows and on a local production build.

## Cause

Two copies of React.

`examples/vite.config.ts` aliases `react-xarrows` to `../src/index.tsx`. That source lives in the repo root, where pnpm installed **React 18.3.1** for the library's own build and tests. The demo runs **React 19.2.8** from `examples/`.

The home route is inline JSX inside the examples module graph, so it uses the demo's React and renders fine. Every other route mounts a component that imports the library, reaches the second React, and finds a null hook dispatcher.

## Fix

`resolve.dedupe: ['react', 'react-dom']`.

Proven against the built bundle rather than inferred:

| | React 19.x | React 18.x | bytes |
|---|---|---|---|
| before | 19.2.8 | **18.3.1** | 360111 |
| after | 19.2.8 | none | 353055 |

## Also

CI built this demo green and shipped a broken site, so this adds a step that fails when the root React version also appears in the demo bundle. Verified it passes on the fixed build and fails on the unfixed one.

## Verification

Local production build (`vite build` + `vite preview`), all five routes loaded in a real browser, console clean:

- `#/` , `#/SimpleExample`, `#/FewArrows`, `#/CustomizeArrow`, `#/differentScrolls`, `#/Playground`

`build-storybook` also still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved demo build reliability by ensuring React uses a single consistent version.
  * Prevented potential runtime errors and inconsistent behavior caused by duplicate React instances.
  * Added validation to detect conflicting React copies during demo builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->