### PR TITLE
fix(xarrow): end the draw phase without an arrowhead, drop invalid repeatCount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ coverage/
 examples/dist/
 examples/dist-storybook/
 examples/.storybook-static/
+
+# git worktrees created for parallel branches
+.worktrees/

--- a/__test__/xarrow.test.tsx
+++ b/__test__/xarrow.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { useRef } from 'react';
 import { describe, expect, it } from 'vitest';
 import Xarrow from '../src/Xarrow/Xarrow';
@@ -55,6 +55,56 @@ describe('Xarrow', () => {
     const { container } = render(<TwoBoxes showHead={false} />);
 
     expect(getPath(container)).toBeInTheDocument();
+  });
+
+  // jsdom implements no SMIL, so nothing here fires on its own. The component
+  // listens with plain addEventListener, so dispatching the events by hand
+  // drives the same code paths a browser would.
+  describe('draw animation', () => {
+    const getDrawAnim = (container: HTMLElement) => container.querySelector('#svgEndAnimate');
+    const getHead = (container: HTMLElement) => container.querySelector<SVGGElement>('svg g:has(> animate)');
+
+    it('ends the draw phase when there is no arrowhead', () => {
+      // Issue #106. The endEvent listener is what ends the draw phase, and it
+      // used to be attached only when an arrowhead existed, so showHead={false}
+      // left the arrow stuck mid-draw forever.
+      const { container } = render(<TwoBoxes showHead={false} animateDrawing />);
+
+      const drawAnim = getDrawAnim(container);
+      expect(drawAnim).not.toBeNull();
+
+      act(() => {
+        drawAnim!.dispatchEvent(new Event('endEvent'));
+      });
+
+      // Once the phase ends the component swaps the draw animation out.
+      expect(getDrawAnim(container)).toBeNull();
+    });
+
+    it('never emits repeatCount="0"', () => {
+      // Issue #193. SMIL has no zero repeat count and the browser logs
+      // "Unexpected value 0 parsing repeatCount attribute" on every arrow.
+      const { container } = render(<TwoBoxes animateDrawing />);
+
+      container.querySelectorAll('animate').forEach((animate) => {
+        expect(animate.getAttribute('repeatCount')).not.toBe('0');
+      });
+    });
+
+    it('leaves the head opacity to React rather than writing an inline style', () => {
+      // An inline style outranks a presentation attribute permanently, and
+      // React only ever writes the attribute, so mutating the style here means
+      // React can never restore the head afterwards.
+      const { container } = render(<TwoBoxes animateDrawing />);
+
+      expect(getHead(container)?.getAttribute('opacity')).toBe('0');
+
+      act(() => {
+        getDrawAnim(container)!.dispatchEvent(new Event('beginEvent'));
+      });
+
+      expect(getHead(container)?.style.opacity).toBe('');
+    });
   });
 
   // Known bug: with curveness 0 (or path="straight") the head angle is computed as

--- a/src/Xarrow/Xarrow.tsx
+++ b/src/Xarrow/Xarrow.tsx
@@ -166,16 +166,18 @@ const Xarrow: React.FC<xarrowPropsType> = (props: xarrowPropsType) => {
         // @ts-ignore
         lineDashAnimRef.current?.beginElement();
       };
-      const handleDrawAmimBegin = () => (headRef.current.style.opacity = '0');
-      if (lineDrawAnimRef.current && headRef.current) {
+      // Deliberately does not depend on the arrowhead. This listener is what
+      // ends the draw phase, and gating it on headRef left `drawAnimEnded`
+      // false forever whenever showHead was false, so the arrow stayed stuck
+      // mid-draw. The head is hidden through the rendered `opacity` attribute
+      // instead, which React can actually reconcile.
+      if (lineDrawAnimRef.current) {
         lineDrawAnimRef.current.addEventListener('endEvent', handleDrawAmimEnd);
-        lineDrawAnimRef.current.addEventListener('beginEvent', handleDrawAmimBegin);
       }
       return () => {
         window.removeEventListener('resize', forceRerender);
         if (lineDrawAnimRef.current) {
           lineDrawAnimRef.current.removeEventListener('endEvent', handleDrawAmimEnd);
-          if (headRef.current) lineDrawAnimRef.current.removeEventListener('beginEvent', handleDrawAmimBegin);
         }
       };
     };
@@ -276,6 +278,9 @@ const Xarrow: React.FC<xarrowPropsType> = (props: xarrowPropsType) => {
                 opacity={animateDrawing && !drawAnimEnded ? 0 : 1}
                 {...(passProps as any)}
                 {...arrowHeadProps}>
+                {/* No repeatCount: SMIL rejects 0 and logs "Unexpected value 0
+                    parsing repeatCount attribute", and the default of a single
+                    run is what this fade-in wants anyway. */}
                 <animate
                   ref={headOpacityAnimRef}
                   dur={'0.4'}
@@ -283,7 +288,6 @@ const Xarrow: React.FC<xarrowPropsType> = (props: xarrowPropsType) => {
                   from="0"
                   to="1"
                   begin={`indefinite`}
-                  repeatCount="0"
                   fill="freeze"
                 />
 


### PR DESCRIPTION
Three changes to the draw-animation block in `src/Xarrow/Xarrow.tsx`.

## 1. `endEvent` no longer depends on the arrowhead — closes #106

```js
if (lineDrawAnimRef.current && headRef.current) {   // before
```

`endEvent` is the listener that sets `drawAnimEnded` and ends the draw phase. Gating it on `headRef.current` meant that with `showHead={false}` **no listener was attached at all**, so the arrow stayed in draw state forever.

Worth noting: the outer guard shipped in 2.0.1 (`eada23f`, 2021-07-26), three months before #106 was filed, so the `TypeError` in that issue's title was already unreachable. The live bug is the stuck arrow, not the crash. That also makes #181 a no-op — it null-checks the inside of a handler that is only ever attached when the ref is non-null.

## 2. Deleted the imperative head-opacity write

```js
const handleDrawAmimBegin = () => (headRef.current.style.opacity = '0');   // removed
```

React renders that same opacity as an *attribute*. An inline style outranks a presentation attribute permanently, so once this ran React could never reconcile the head again; only the SMIL `fill="freeze"` fade rescued it. The attribute already hides the head while drawing, so this is deleted rather than guarded.

## 3. `repeatCount="0"` — closes #193

Invalid SMIL. Logs `Unexpected value 0 parsing repeatCount attribute` on every arrow. The default single run is what the fade-in wants.

## Tests

jsdom implements no SMIL, so the tests dispatch `beginEvent` / `endEvent` by hand onto the animation element, which drives the same listener code paths a browser would. All three **fail against current master and pass against this branch** — verified, not assumed:

```
× ends the draw phase when there is no arrowhead
× never emits repeatCount="0"
× leaves the head opacity to React rather than writing an inline style
```

## What this does NOT fix

**#105 is still open and is a different root cause.** Instrumenting a real page showed the draw animation mounting as `values="0;0"` — `st.lineLength` is still 0 because it is measured in a `useLayoutEffect` that runs after the `<animate>` has already been committed.

## Caveat on verification

I could not confirm the animation end-to-end in a browser. SMIL does not run in the Chrome 151 instance available here: a plain HTML-parsed `<animate>` never fires, and `svg.getCurrentTime()` stays pinned at 0. Worth establishing separately whether that is an automation-profile quirk or real, because if Chrome has dropped SMIL then every animation feature in this library is affected. The unit tests carry the proof for this PR.

Also folds in a one-line `.gitignore` entry for `.worktrees/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)