### PR TITLE
ci: configure Netlify so deploy previews actually build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,17 @@
+# Netlify builds deploy previews for pull requests. Without this file it
+# auto-detects, and auto-detection cannot work on this repo: the site lives in
+# examples/, but it resolves the library from ../src through a Vite alias, so it
+# has to be built from the repo root. The root `build` script builds the library
+# into lib/, which is not a website.
+
+[build]
+  command = "pnpm --filter react-xarrows-examples run build"
+  publish = "examples/dist"
+
+[build.environment]
+  # Matches the version CI runs. jsdom 30 and Vite 8 both want Node 22+.
+  NODE_VERSION = "22"
+
+# GITHUB_PAGES is deliberately not set here. examples/vite.config.ts reads it to
+# decide between the /react-xarrows/ base that GitHub Pages needs and the root
+# base that Netlify serves from. Setting it would break every asset URL.


### PR DESCRIPTION
Netlify is connected for preview URLs but has **never** produced a successful deploy. `react-xarrows.netlify.app` currently returns 404, and the checks on #208 are all `Deploy failed`.

## Why it fails

There is no `netlify.toml`, so Netlify falls back to auto-detection, and auto-detection cannot work on this repo:

- the site lives in `examples/`, not the repo root
- but it cannot be built *from* `examples/` either, because it resolves the library from `../src` through a Vite alias, so a base directory of `examples/` would not see it
- and the root `build` script builds the **library** into `lib/`, which is not a website

## Fix

Pins the build command, publish directory and Node version.

```toml
command = "pnpm --filter react-xarrows-examples run build"
publish = "examples/dist"
NODE_VERSION = "22"
```

`GITHUB_PAGES` is deliberately left unset. `examples/vite.config.ts` reads it to choose between the `/react-xarrows/` base GitHub Pages needs and the root base Netlify serves from, so setting it here would break every asset URL. Verified locally that with it unset the emitted `index.html` references `/assets/...`, which is what Netlify wants.

## This PR tests itself

Netlify reads `netlify.toml` from the pull request branch, so the deploy preview check **on this PR** is the verification. If it goes green, previews work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Netlify deploy preview configuration.
  * Configured previews to build and publish the examples site.
  * Updated the deployment environment to use Node.js 22.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->