### PR TITLE
refactor: depend on the position numbers instead of a memo helper

### DIFF
--- a/src/Xarrow/useXarrowProps.ts
+++ b/src/Xarrow/useXarrowProps.ts
@@ -293,31 +293,6 @@ const initialValVars = {
 
 // const parseAllProps = () => parseGivenProps(defaultProps, initialParsedProps);
 
-// The only values ever compared here are element positions, which getElemPos
-// always returns as four numbers, including on its null-element branch. A
-// general deep-equality helper (this used to be lodash isEqual) is more than
-// this needs, and would also have to be careful around the refs and React
-// elements that appear elsewhere in the props.
-const samePosition = (a: dimensionType | undefined, b: dimensionType | undefined) => {
-  if (a === b) return true;
-  if (!a || !b) return false;
-  return a.x === b.x && a.y === b.y && a.right === b.right && a.bottom === b.bottom;
-};
-
-function usePositionMemoize(value: dimensionType) {
-  const ref = useRef<dimensionType>();
-
-  if (!samePosition(value, ref.current)) {
-    ref.current = value;
-  }
-
-  return ref.current;
-}
-
-function usePositionEffect(callback: () => void, dependencies: dimensionType[]) {
-  useLayoutEffect(callback, dependencies.map(usePositionMemoize));
-}
-
 /**
  * smart hook that provides parsed props to Xarrow and will trigger rerender whenever given prop is changed.
  */
@@ -354,19 +329,21 @@ const useXarrowProps = (
   // rerender whenever position of start element or end element changes
   const [valVars, setValVars] = useState(initialValVars);
   const startPos = getElemPos(propsRefs.start);
-  usePositionEffect(() => {
+  // getElemPos returns a fresh object every render, so the four numbers are the
+  // dependencies, not the object. This used to run through a lodash isEqual
+  // memo helper that called useRef from inside dependencies.map(), which is a
+  // hook in a callback and wrote to the ref during render.
+  useLayoutEffect(() => {
     valVars.startPos = startPos;
     shouldUpdatePosition.current = true;
     setValVars({ ...valVars });
-    // console.log('start update pos', startPos);
-  }, [startPos]);
+  }, [startPos.x, startPos.y, startPos.right, startPos.bottom]);
   const endPos = getElemPos(propsRefs.end);
-  usePositionEffect(() => {
+  useLayoutEffect(() => {
     valVars.endPos = endPos;
     shouldUpdatePosition.current = true;
     setValVars({ ...valVars });
-    // console.log('end update pos', endPos);
-  }, [endPos]);
+  }, [endPos.x, endPos.y, endPos.right, endPos.bottom]);
 
   useLayoutEffect(() => {
     // console.log('svg shape changed!');


### PR DESCRIPTION
Follow-up to #212. This commit was pushed to that branch but landed after it was merged, so it never reached `main`.

## What it fixes

CodeRabbit's review point on #212, which was correct:

> `usePositionMemoize` calls `useRef` from a callback and writes `ref.current` during render.

`useLayoutEffect(callback, dependencies.map(usePositionMemoize))` calls a hook inside a `.map()` callback, and mutates the ref during render.

## Why the simple version works

The comparison was only ever four numbers, so the four numbers can be the dependency array:

```js
useLayoutEffect(() => { ... }, [startPos.x, startPos.y, startPos.right, startPos.bottom]);
```

That removes `samePosition`, `usePositionMemoize` and `usePositionEffect` outright rather than relocating the `useRef`. The effect fires on exactly the same condition as before. **31 lines deleted, 8 added.**

## History

The hook-in-a-callback predates all of this. The original was `useLayoutEffect(callback, dependencies.map(useDeepCompareMemoize))` with a lodash `isEqual` inside; #212 swapped the equality function and kept the shape. It only existed to work around comparing an object that `getElemPos` rebuilds every render, which stops being a problem once the dependencies are primitives.

## Verification

Rendered five prop combinations against the `main` build and this one and diffed the markup: **byte identical**. 53 library tests and 2 demo tests pass, type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved arrow positioning updates when connected elements move.
  * Ensured start and end positions refresh reliably as individual coordinates change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->