### PR TITLE
chore: prepare the 2.1.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
+  # Called by publish.yml so a release runs the exact same checks a PR does,
+  # rather than a subset that can drift away from this file.
+  workflow_call:
 
 # A newer push to the same branch makes the in-flight run irrelevant.
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
     # Node 22 LTS. It is the lower bound we support: jsdom 30 needs the undici
     # that ships with Node 22+, and anything passing here passes on 24.
     runs-on: ubuntu-latest
+    # The whole suite runs in about a minute. Anything near this limit is hung,
+    # and the default of six hours is a long time to hold up a release.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
 
@@ -67,12 +70,16 @@ jobs:
 
       # Catches the case where `files` or the build output drift apart and the
       # published tarball silently loses an entry point or its type definitions.
+      # index.d.mts and index.d.cts are here because the exports map points the
+      # per-condition `types` at them, and they come from a copy step in
+      # vite.config.mts that would fail quietly. Paths are anchored so a
+      # sourcemap cannot stand in for the file it maps.
       - name: Verify package contents
         run: |
           pnpm pack --pack-destination /tmp
           tar tzf /tmp/react-xarrows-*.tgz | sort
-          for f in index.mjs index.cjs index.umd.js index.d.ts; do
-            tar tzf /tmp/react-xarrows-*.tgz | grep -q "package/lib/$f"
+          for f in index.mjs index.cjs index.umd.js index.d.ts index.d.mts index.d.cts; do
+            tar tzf /tmp/react-xarrows-*.tgz | grep -qx "package/lib/$f"
           done
 
       # Catches exports-map and declaration mismatches, such as an ESM entry

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,15 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # The full CI suite, not a copy of part of it. Publishing used to re-run
+  # lint/type-check/test/build inline, which silently skipped the checks that
+  # actually guard the tarball: format, the demo build and tests, attw, package
+  # contents, and the entry-point smoke tests.
+  verify:
+    uses: ./.github/workflows/ci.yml
+
   publish:
+    needs: verify
     runs-on: ubuntu-latest
 
     steps:
@@ -39,15 +47,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Lint
-        run: pnpm run lint
-
-      - name: Type-check
-        run: pnpm run type-check
-
-      - name: Test
-        run: pnpm run test
-
+      # The verify job runs in its own checkout, so lib/ has to be rebuilt here
+      # before npm publish can pack it. Everything else it checked already.
       - name: Build
         run: pnpm run build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,48 @@
+## 2.1.0
+
+First release since February 2024. No API changes: every prop, component and
+hook behaves as it did in 2.0.2.
+
+### bug fixes
+
+- arrows no longer render at `NaN` coordinates when `start` and `end` sit at the
+  same point, which includes the very common case of elements that have not been
+  measured yet on first render. The whole arrow used to disappear.
+  [#139](https://github.com/Eliav2/react-xarrows/issues/139)
+  [#171](https://github.com/Eliav2/react-xarrows/issues/171)
+  [#192](https://github.com/Eliav2/react-xarrows/issues/192)
+- the draw animation now completes when the arrow has no arrowhead
+  (`showHead={false}`), and no longer emits an invalid `repeatCount="0"`.
+  Reported by [@dthomasen](https://github.com/dthomasen) in
+  [#181](https://github.com/Eliav2/react-xarrows/pull/181).
+  [#193](https://github.com/Eliav2/react-xarrows/issues/193)
+- dashed and dotted line animation works under `StrictMode`. Thanks to
+  [@Reflejo](https://github.com/Reflejo) for the fix.
+  [#174](https://github.com/Eliav2/react-xarrows/pull/174)
+
+### packaging
+
+- **zero runtime dependencies.** `lodash`, `prop-types` and `@types/react` were
+  all removed from `dependencies`. React is now the only peer dependency, so
+  installing react-xarrows adds nothing else to your tree.
+- **real ESM, CommonJS and UMD builds.** 2.0.2 shipped a single UMD file, which
+  no bundler can tree-shake, so every consumer paid for the whole library.
+  [#118](https://github.com/Eliav2/react-xarrows/issues/118)
+- types now resolve correctly under `moduleResolution: node16`/`bundler` for both
+  the `import` and `require` conditions.
+
+### behavior changes
+
+None of these change the API, but they can matter depending on your setup.
+
+- **build target moved from ES5 to ES2015.** If you transpile `node_modules` down
+  to ES5, react-xarrows now needs to be included in that pass. The project's
+  browserslist already excluded IE11, so ES5 output was only costing bytes.
+- **runtime prop validation is gone.** `prop-types` was a runtime dependency used
+  only for development warnings. JavaScript users on React 18 and below no longer
+  get those warnings. TypeScript users are unaffected, and React 19 ignores
+  `propTypes` entirely, so it was already dead weight there.
+
 ## 2.0.2
 
 - prop suggestions did not appear on IDE's because wrong package.json.types path.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,5 @@
 # react-xarrows
 
-## ⚠️Warning⚠️
-
-I'm no longer maintaining this project, as evident from the commit history. It Started 5 years ago due to a lack of good React libraries for SVG arrows/lines, but better alternatives exist today, like [react-flow](https://reactflow.dev/) (unrelated to me).
-react-xarrows v3 is 75% ready in my stash, but I won't work on it for now due to other projects. 
-
-Thanks for the journey, happy development!
-
 ## introduction
 
 Draw arrows between components in React!
@@ -22,16 +15,21 @@ Draw arrows between components in React!
 - Super simple API yet fully customizable usage!
 - Smart and Intuitive look and behavior!
 - Smart React lifecycle, and cached parsed props for efficiency!
+- Zero runtime dependencies. React is the only peer dependency.
+- Ships ESM, CommonJS and UMD, with types resolving correctly under every one.
 
 liked my work? star [this repo](https://github.com/Eliav2/react-xarrows).
 
 reallyy liked my work? [buy me a coffee](https://www.paypal.com/donate?hosted_button_id=CRQ343F9VTRS8)!  
 
-## Help wanted
+## Project status
 
-This project needs another maintainer, especially for known bugs(and future ones) of react-xarrows v2. 
-I'm working on V3 from time to time, but don't have the time to respond and fix all active issues. 
-help would be welcomed(contact me on louski.a@gmail.com for more details)  
+Actively maintained again after a long gap. The v2 line is where the work is
+happening: open bugs are being fixed, the build and CI were rebuilt, and
+releases are published from CI with npm provenance.
+
+Contributions are welcome. Issues with a reproduction get looked at first, and
+[/examples](./examples) has a story per fixed bug that you can copy to build one.
 
 ## installation
 


### PR DESCRIPTION
Everything that should land before the version bump. No source changes, so the published behavior of the library is untouched by this PR.

## README

Drops the "I'm no longer maintaining this project" banner. It sat above everything else and is no longer true. Replaced the `Help wanted` section with a `Project status` section that says what is actually happening, and added the two new packaging facts to the feature list.

## CHANGELOG

`CHANGELOG.md` is in `files`, so it ships inside the tarball. It currently stops at 2.0.2, which means the published package documents none of the last week's work.

The entry is explicit about the two things that can break a working setup even though no API changed:

- **ES5 to ES2015 output.** Anyone transpiling `node_modules` down to ES5 now has to include react-xarrows in that pass.
- **prop-types removed.** JavaScript users on React 18 and below lose dev-time prop warnings. TypeScript users and React 19 users are unaffected.

Contributor credit for #174 (@Reflejo) and #181 (@dthomasen).

## publish.yml

This is the one worth a look. The publish job re-ran `lint`, `type-check`, `test` and `build` inline. That is a subset of `ci.yml` that had already drifted: it skipped `format:check`, the demo build and tests, `attw`, the package-contents check, and the entry-point and UMD smoke tests. Those are precisely the checks that catch a broken tarball, and 2.1.0 is the first release ever to go out through Trusted Publishing.

`publish.yml` now calls `ci.yml` as a reusable workflow and depends on it. The only step kept inline is `build`, because the publish job publishes from its own checkout and needs `lib/` present.

Cost: CI runs twice on a version-bump push, once from `ci.yml`'s own `push: main` trigger and once inside the publish run. They land in different concurrency groups so neither cancels the other.

## Also done outside this PR

- Closed #175 and #181, both superseded, with credit.
- Deleted the stale `refactor/drop-runtime-deps` branch.

## Left for after 2.1.0

#178 (`roundedCorners`) is a real feature and conflicts with main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)