### PR TITLE
chore(release): 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-xarrows",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "author": "Eliav Louski",
   "description": "Draw arrows (or lines) between components in React!",
   "main": "./lib/index.cjs",


### PR DESCRIPTION
Bumps `version` from 2.0.2 to 2.1.0. One line, nothing else touched.

## ⚠️ Merging this publishes to npm

This is the trigger, not a preparation step. On merge, `publish.yml` fires on the `package.json` path filter and:

1. runs the full `ci.yml` suite as a required upstream job
2. `npm publish` with provenance, via **Trusted Publishing, exercised for real for the first time**
3. creates the `v2.1.0` GitHub release with generated notes

npm versions cannot be republished or unpublished after 72 hours (and unpublishing is disruptive well before that). Merge when you actually want 2.1.0 live.

## Pre-flight already done

The publish workflow was dry-run on the #214 branch (run [31282647710](https://github.com/Eliav2/react-xarrows/actions/runs/31282647710)). `verify / verify` resolved and passed, `publish` gated on it correctly, and the version guard skipped `npm publish`, `Update npm` and `Create GitHub release` because 2.0.2 was already live. So the wiring is proven; only the version guard's answer changes this time.

Packed the 2.1.0 tarball locally:

```
94469 bytes
package/lib/index.mjs      OK
package/lib/index.cjs      OK
package/lib/index.umd.js   OK
package/lib/index.d.ts     OK
package/lib/index.d.mts    OK
package/lib/index.d.cts    OK

version     2.1.0
deps        {}
peerDeps    {"react":">=16.8.0"}
```

Zero runtime dependencies in the published manifest, which is the headline change of the release.

## What 2.1.0 contains

Already on main, fully described in `CHANGELOG.md`. Summary:

- **fixes**: NaN geometry when start and end coincide (#139, #171, #192), draw animation with no arrowhead plus the invalid `repeatCount="0"` (#193, #181), dotted animation under StrictMode (#174)
- **packaging**: zero runtime deps, real ESM/CJS/UMD instead of UMD-only (#118), types resolving per condition
- **behavior changes, no API change**: build target ES5 to ES2015, and prop-types removed so JS users on React 18 and below lose dev-time prop warnings

## If the publish fails

It fails closed. The version guard is idempotent and the release step checks for an existing tag, so re-running the workflow is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 2.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->